### PR TITLE
Fixed broken CONTRIBUTING.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![devDependencies Status](https://david-dm.org/liskHQ/lisk-desktop/dev-status.svg)](https://david-dm.org/liskHQ/lisk-desktop?type=dev)
 
 ## For Contributors
-Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for more information.
+Please see [CONTRIBUTING_GUIDE.md](/docs/CONTRIBUTING_GUIDE.md) for more information.
 ## Development
 
 ```


### PR DESCRIPTION
### What was the problem?
The README.md file had a broken CONTRIBUTING link

### How was it solved?
Changed the CONTRIBUTING.md link to docs/CONTRIBUTING_GUIDE.md

### How was it tested?
Re-visited the Github page, link works now.
